### PR TITLE
Open test reports phase 1

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>open-liberty-tools-eclipse-test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/liberty/META-INF/MANIFEST.MF
+++ b/liberty/META-INF/MANIFEST.MF
@@ -7,21 +7,12 @@ Bundle-Activator: liberty.tools.LibertyDevPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.13.700",
- org.eclipse.ui.console;bundle-version="[3.9.0,3.10.0)",
  org.eclipse.jdt.core;bundle-version="[3.21.0,4.0.0)",
  org.eclipse.jem.util;bundle-version="2.1.201",
  org.gradle.toolingapi;bundle-version="[6.0.0,7.0.0)",
- org.eclipse.tm.terminal.connector.local;bundle-version="[4.6.0,5.0.0)",
- org.eclipse.tm.terminal.connector.process;bundle-version="[4.6.0,5.0.0)",
- org.eclipse.tm.terminal.connector.ssh;bundle-version="[4.6.0,5.0.0)",
- org.eclipse.tm.terminal.connector.telnet;bundle-version="[4.6.0,5.0.0)",
- org.eclipse.tm.terminal.control;bundle-version="[4.6.1,6.0.0)",
  org.eclipse.tm.terminal.view.core;bundle-version="[4.6.0,5.0.0)",
- org.eclipse.tm.terminal.view.ui;bundle-version="[4.6.0,5.0.0)",
- org.eclipse.tm4e.core;bundle-version="[0.4.0,1.0.0)",
- org.eclipse.tm4e.languageconfiguration;bundle-version="[0.3.4,1.0.0)",
- org.eclipse.tm4e.registry;bundle-version="[0.4.0,1.0.0)",
- org.eclipse.tm4e.ui;bundle-version="[0.4.0,1.0.0)"
+ org.eclipse.ui.browser;bundle-version="3.7.100",
+ org.eclipse.ui.console;bundle-version="3.9.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: liberty
 Bundle-ActivationPolicy: lazy

--- a/liberty/src/liberty/tools/DevModeOperations.java
+++ b/liberty/src/liberty/tools/DevModeOperations.java
@@ -1,201 +1,349 @@
 package liberty.tools;
 
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
-
-import liberty.tools.utils.Dialog;
-import liberty.tools.utils.Project;
-import org.eclipse.tm.internal.terminal.*;
 import org.eclipse.tm.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.tm.terminal.view.core.interfaces.ITerminalService;
 import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.browser.IWebBrowser;
+import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
+
+import liberty.tools.utils.Dialog;
+import liberty.tools.utils.Project;
 
 /**
  * Provides the implementation of all supported dev mode operations.
  */
 public class DevModeOperations {
 
-	// TODO: Figure out if there are any special needs for Windows/Linux.
-	// TODO: Figure out how to get this dynamically from the eclipse configuration,
-	// and establish precedence.
-	private final String MVN_INSTALL = "/Users/mezarin/tools/maven/apache-maven-3.6.3";
-	private final String JAVA_HOME = "/Users/mezarin/tools/java/sdks/openjdk/jdk-11.0.8+10/Contents/Home";
+    // TODO: Figure out if there are any special needs for Windows/Linux.
+    // TODO: Establish a Maven/Gradle command precedence (i.e. gradlew ->
+    // gradle_home).
 
-	/**
-	 * Starts the server in development mode.
-	 * 
-	 * @return An error message or null if the command was processed successfully.
-	 */
-	public void start() {
-		IProject project = Project.getSelected();
-		String projectPath = Project.getPath(project);
-		if (projectPath == null) {
-			Dialog.displayErrorMessage("Unable to find the path to selected project. Be sure to select one.");
-			return;
-		}
-		String cmd = "";
-		if (Project.isMaven(project)) {
-			if (!Project.isMavenBuildFileValid(project)) {
-				System.out.println("Maven build file on project" + project.getName() + " is not valid..");
-			}
-			cmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev -f " + projectPath;
-		} else if (Project.isGradle(project)) {
-			if (!Project.isGradleBuildFileValid(project)) {
-				System.out.println("Build file on project" + project.getName() + " is not valid.");
-			}
-			cmd = "gradle libertyDev -b=" + projectPath;
-		} else {
-			Dialog.displayErrorMessage("Project " + project.getName() + " is not a Gradle or Maven project.");
-			return;
-		}
+    /**
+     * Starts the server in development mode.
+     * 
+     * @return An error message or null if the command was processed successfully.
+     */
+    public void start() {
+        IProject project = Project.getSelected();
+        String projectPath = Project.getPath(project);
+        if (projectPath == null) {
+            Dialog.displayErrorMessage("Unable to find the path to selected project: " + project.getName());
+            return;
+        }
+        String cmd = "";
+        if (Project.isMaven(project)) {
+            if (!Project.isMavenBuildFileValid(project)) {
+                System.out.println("Maven build file on project" + project.getName() + " is not valid..");
+            }
+            cmd += getMavenInstallPath() + "/";
+            cmd += "mvn io.openliberty.tools:liberty-maven-plugin:dev -f " + projectPath;
+        } else if (Project.isGradle(project)) {
+            if (!Project.isGradleBuildFileValid(project)) {
+                System.out.println("Build file on project" + project.getName() + " is not valid.");
+            }
+            cmd += getGradleInstallPath() + "/";
+            cmd += "gradle libertyDev -b=" + projectPath;
+        } else {
+            Dialog.displayErrorMessage("Project" + project.getName() + "is not a Gradle or Maven project.");
+            return;
+        }
 
-		try {
-			runCommand(cmd);
-		} catch (Exception e) {
-			Dialog.displayErrorMessageWithDetails("An error was detected while performing the start action.", e);
-			return;
-		}
+        try {
+            runCommand(cmd);
+        } catch (Exception e) {
+            Dialog.displayErrorMessageWithDetails("An error was detected while performing the start action.", e);
+            return;
+        }
 
-	}
+    }
 
-	/**
-	 * Starts the server in development mode.
-	 * 
-	 * @return An error message or null if the command was processed successfully.
-	 */
-	public void startWithParms(String userParms) {
-		IProject project = Project.getSelected();
-		String projectPath = Project.getPath(project);
-		if (projectPath == null) {
-			Dialog.displayErrorMessage("Unable to find the path to selected project. Be sure to select one.");
-			return;
-		}
-		String cmd = "";
-		if (Project.isMaven(project)) {
-			cmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev " + userParms + " -f " + projectPath;
-		} else if (Project.isGradle(project)) {
-			cmd = "gradle libertyDev " + userParms + " -b=" + projectPath;
-		} else {
-			Dialog.displayErrorMessage("Project" + project.getName() + "is not a Gradle or Maven project.");
-			return;
-		}
+    /**
+     * Starts the server in development mode.
+     * 
+     * @return An error message or null if the command was processed successfully.
+     */
+    public void startWithParms(String userParms) {
+        IProject project = Project.getSelected();
+        String projectPath = Project.getPath(project);
+        if (projectPath == null) {
+            Dialog.displayErrorMessage("Unable to find the path to selected project: " + project.getName());
+            return;
+        }
+        String cmd = "";
+        if (Project.isMaven(project)) {
+            cmd += getMavenInstallPath() + "/";
+            cmd += "mvn io.openliberty.tools:liberty-maven-plugin:dev " + userParms + " -f " + projectPath;
+        } else if (Project.isGradle(project)) {
+            cmd += getGradleInstallPath() + "/";
+            cmd += "gradle libertyDev " + userParms + " -b=" + projectPath;
+        } else {
+            Dialog.displayErrorMessage("Project" + project.getName() + "is not a Gradle or Maven project.");
+            return;
+        }
 
-		System.out.println("@ed Command to run: " + cmd);
-		try {
-			runCommand(cmd);
-		} catch (Exception e) {
-			Dialog.displayErrorMessageWithDetails("An error was detected while performing the start... action.", e);
-			return;
-		}
-	}
+        try {
+            runCommand(cmd);
+        } catch (Exception e) {
+            Dialog.displayErrorMessageWithDetails("An error was detected while performing the start... action.", e);
+            return;
+        }
+    }
 
-	/**
-	 * Starts the server in development mode.
-	 * 
-	 * @return An error message or null if the command was processed successfully.
-	 */
-	public void startInContainer() {
-		IProject project = Project.getSelected();
-		String projectPath = Project.getPath(project);
-		if (projectPath == null) {
-			Dialog.displayErrorMessage("Unable to find the path to selected project. Be sure to select one.");
-			return;
-		}
+    /**
+     * Starts the server in development mode.
+     * 
+     * @return An error message or null if the command was processed successfully.
+     */
+    public void startInContainer() {
+        IProject project = Project.getSelected();
+        String projectPath = Project.getPath(project);
+        if (projectPath == null) {
+            Dialog.displayErrorMessage("Unable to find the path to selected project: " + project.getName());
+            return;
+        }
 
-		String cmd = "";
-		if (Project.isMaven(project)) {
-			cmd = "mvn io.openliberty.tools:liberty-maven-plugin:devc -f " + projectPath;
-		} else if (Project.isGradle(project)) {
-			cmd = "gradle libertyDevc -b=" + projectPath;
-		} else {
-			Dialog.displayErrorMessage("Project" + project.getName() + "is not a Gradle or Maven project.");
-		}
+        String cmd = "";
+        if (Project.isMaven(project)) {
+            cmd += getMavenInstallPath() + "/";
+            cmd += "mvn io.openliberty.tools:liberty-maven-plugin:devc -f " + projectPath;
+        } else if (Project.isGradle(project)) {
+            cmd += getGradleInstallPath() + "/";
+            cmd += "gradle libertyDevc -b=" + projectPath;
+        } else {
+            Dialog.displayErrorMessage("Project" + project.getName() + "is not a Gradle or Maven project.");
+        }
 
-		try {
-			runCommand(cmd);
-		} catch (Exception e) {
-			Dialog.displayErrorMessageWithDetails("An error was detected while performing the start in container action.",
-					e);
-			return;
-		}
-	}
+        try {
+            runCommand(cmd);
+        } catch (Exception e) {
+            Dialog.displayErrorMessageWithDetails(
+                    "An error was detected while performing the start in container action.", e);
+            return;
+        }
+    }
 
-	/**
-	 * Starts the server in development mode.
-	 * 
-	 * @return An error message or null if the command was processed successfully.
-	 */
-	public void stop() {
-		String cmd = "exit";
-		try {
-			runCommand(cmd);
-		} catch (Exception e) {
-			Dialog.displayErrorMessageWithDetails("An error was detected while performing the stop action.", e);
-			return;
-		}
-	}
+    /**
+     * Starts the server in development mode.
+     * 
+     * @return An error message or null if the command was processed successfully.
+     */
+    public void stop() {
+        String cmd = "q";
+        try {
+            runCommand(cmd);
+        } catch (Exception e) {
+            Dialog.displayErrorMessageWithDetails("An error was detected while performing the stop action.", e);
+            return;
+        }
+    }
 
-	/**
-	 * Runs the tests provided by the application.
-	 * 
-	 * @return An error message or null if the command was processed successfully.
-	 */
-	public void runTests() {
-		String cmd = " ";
-		try {
-			runCommand(cmd);
-		} catch (Exception e) {
-			Dialog.displayErrorMessageWithDetails("An error was detected while performing the run tests action.", e);
-			return;
-		}
-	}
+    /**
+     * Runs the tests provided by the application.
+     * 
+     * @return An error message or null if the command was processed successfully.
+     */
+    public void runTests() {
+        String cmd = " ";
+        try {
+            runCommand(cmd);
+        } catch (Exception e) {
+            Dialog.displayErrorMessageWithDetails("An error was detected while performing the run tests action.", e);
+            return;
+        }
+    }
 
-	/**
-	 * Opens test reports.
-	 */
-	public void openTestReports() {
-		// TODO1: Find the location of the files.
-		// TODO2: Display them in a view.
-	}
+    /**
+     * Open Maven integration test report.
+     */
+    public void openMavenIntegrationTestReport() {
+        IProject project = Project.getSelected();
+        String projectPath = Project.getPath(project);
+        if (projectPath == null) {
+            Dialog.displayErrorMessage("Unable to find the path to selected project: " + project.getName());
+            return;
+        }
 
-	/**
-	 * Runs the specified command on a terminal.
-	 * 
-	 * @param cmd The command to run.
-	 * 
-	 * @throws Exception If an error occurs while running the specified command.
-	 */
-	public void runCommand(String cmd) throws Exception {
-		// TODO: Implement me.
-		
-		System.out.println("AJM: trying to open a terminal");
-		// Define the terminal properties
-		Map<String, Object> properties = new HashMap<String, Object>();
-		properties.put(ITerminalsConnectorConstants.PROP_TITLE, "My Local Terminal");
-		properties.put(ITerminalsConnectorConstants.PROP_ENCODING, "UTF-8");
-		properties.put(ITerminalsConnectorConstants.PROP_PROCESS_WORKING_DIR, ".");
-		properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID, "org.eclipse.tm.terminal.connector.local.launcher.local");
-		//properties.put(ITerminalsConnectorConstants.PROP_PROCESS_ENVIRONMENT, "bash");
-		//properties.put(ITerminalsConnectorConstants.PROP_PROCESS_PATH, "dir");
-		//properties.put(ITerminalsConnectorConstants.PROP_PROCESS_ARGS, "-la");
+        String browserId = "maven.failsafe.integration.test.results";
+        String name = "Maven Failsafe integration test results";
+        Path path = Paths.get(projectPath, "target", "site", "failsafe-report.html");
 
+        openTestReport(project.getName(), path, browserId, name, name);
+    }
 
-		// Create the done callback object
-		ITerminalService.Done done = new ITerminalService.Done() {
-		    public void done(IStatus done) {
-		        // Place any post processing here
-		    }
-		};
+    /**
+     * Open Maven unit test report.
+     */
+    public void openMavenUnitTestReport() {
+        IProject project = Project.getSelected();
+        String projectPath = Project.getPath(project);
+        if (projectPath == null) {
+            Dialog.displayErrorMessage("Unable to find the path to selected project: " + project.getName());
+            return;
+        }
 
-		// Open the terminal
-		ITerminalService terminal = TerminalServiceFactory.getService();
-		if (terminal != null) terminal.openConsole(properties, done);
-		System.out.println("AJM: terminal created?");
-        
-		//throw new UnsupportedOperationException(
-		//		"start Not yet implemented. Waiting for a brave soul to do it. Not sure how to do this!");
-	}
+        String browserId = "maven.project.surefire.unit.test.results";
+        String name = "Maven Surefire unit test results";
+        Path path = Paths.get(projectPath, "target", "site", "surefire-report.html");
+        openTestReport(project.getName(), path, browserId, name, name);
+    }
+
+    /**
+     * Open Gradle test report.
+     */
+    public void openGradleTestReport() {
+        IProject project = Project.getSelected();
+        String projectPath = Project.getPath(project);
+        if (projectPath == null) {
+            Dialog.displayErrorMessage("Unable to find the path to selected project: " + project.getName());
+            return;
+        }
+
+        String browserId = "gradle.project.test.results";
+        String name = "Gradle project test results";
+
+        openTestReport(project.getName(), getGradleTestReportPath(projectPath), browserId, name, name);
+    }
+
+    /**
+     * Opens the specified report in a browser.
+     * 
+     * @param reportRelPath
+     * @param browserId
+     * @param name
+     * @param toolTip
+     */
+    public void openTestReport(String projName, Path path, String browserId, String name, String toolTip) {
+        try {
+            URL url = path.toUri().toURL();
+            IWorkbenchBrowserSupport bSupport = PlatformUI.getWorkbench().getBrowserSupport();
+            IWebBrowser browser = null;
+            if (bSupport.isInternalWebBrowserAvailable()) {
+                browser = bSupport.createBrowser(
+                        IWorkbenchBrowserSupport.AS_EDITOR | IWorkbenchBrowserSupport.LOCATION_BAR
+                                | IWorkbenchBrowserSupport.NAVIGATION_BAR | IWorkbenchBrowserSupport.STATUS,
+                        browserId, name, toolTip);
+            } else {
+                browser = bSupport.createBrowser(browserId);
+            }
+
+            browser.openURL(url);
+        } catch (Exception e) {
+            Dialog.displayErrorMessageWithDetails(
+                    "An error was detected while retrieving " + name + " for project " + projName, e);
+            return;
+        }
+    }
+
+    /**
+     * Runs the specified command on a terminal.
+     * 
+     * @param cmd The command to run.
+     * 
+     * @throws Exception If an error occurs while running the specified command.
+     */
+    public void runCommand(String cmd) throws Exception {
+        ITerminalService.Done done = new ITerminalService.Done() {
+            public void done(IStatus done) {
+            }
+        };
+
+        List<String> envs = new ArrayList<String>(1);
+        envs.add("JAVA_HOME=" + getJavaInstallPath());
+
+        Map<String, Object> properties = new HashMap<String, Object>();
+        properties.put(ITerminalsConnectorConstants.PROP_TITLE, "Liberty DevMode");
+        properties.put(ITerminalsConnectorConstants.PROP_ENCODING, "UTF-8");
+        properties.put(ITerminalsConnectorConstants.PROP_DELEGATE_ID,
+                "org.eclipse.tm.terminal.connector.local.launcher.local");
+        properties.put(ITerminalsConnectorConstants.PROP_PROCESS_PATH, cmd);
+        properties.put(ITerminalsConnectorConstants.PROP_PROCESS_ENVIRONMENT, envs.toArray(new String[envs.size()]));
+        properties.put(ITerminalsConnectorConstants.PROP_PROCESS_MERGE_ENVIRONMENT, true);
+        ITerminalService ts = TerminalServiceFactory.getService();
+        ts.openConsole(properties, done);
+    }
+
+    /**
+     * Returns the path to the Java installation.
+     * 
+     * @return The path to the Java installation.
+     */
+    private String getJavaInstallPath() {
+        String javaHome = null;
+        // TODO: 1. Find the eclipse->java configured install path
+
+        // 2. Check for associated system properties.
+        if (javaHome == null) {
+            javaHome = System.getProperty("java.home");
+        }
+
+        // 3. Check for associated environment property.
+        if (javaHome == null) {
+            javaHome = System.getenv("JAVA_HOME");
+        }
+
+        return javaHome;
+    }
+
+    /**
+     * Returns the path to the Maven installation.
+     * 
+     * @return The path to the Maven installation.
+     */
+    private String getMavenInstallPath() {
+        String mvnInstall = null;
+        // TODO: 1. Find the eclipse->maven configured install path
+
+        // 2. Check for associated environment property.
+        if (mvnInstall == null) {
+            mvnInstall = System.getenv("MAVEN_HOME");
+
+            if (mvnInstall == null) {
+                mvnInstall = System.getenv("M2_MAVEN");
+            }
+        }
+
+        return mvnInstall;
+    }
+
+    /**
+     * Returns the path to the Gradle installation.
+     * 
+     * @return The path to the Gradle installation.
+     */
+    private String getGradleInstallPath() {
+        // TODO: 1. Find the eclipse->gradle configured install path.
+
+        // 2. Check for associated environment property.
+        String mvnInstall = System.getenv("GRADLE_HOME");
+
+        return mvnInstall;
+    }
+
+    /**
+     * Returns the path to the HTML test report.
+     * 
+     * @return The HTML default located in the configured in the build file or the default location.
+     */
+    private Path getGradleTestReportPath(String projectPath) {
+        // TODO: Look for custom dir entry in build.gradle:
+        // "test.reports.html.destination". Need to handle a value like this:
+        // reports.html.destination = file("$buildDir/edsTestReports/teststuff")
+        // Notice the use of a variable: $buildDir.
+
+        // If a custom path was not defined, use default value.
+        Path path = Paths.get(projectPath, "build", "reports", "tests", "test", "index.html");
+
+        return path;
+    }
 }

--- a/liberty/src/liberty/tools/LibertyDevPlugin.java
+++ b/liberty/src/liberty/tools/LibertyDevPlugin.java
@@ -8,37 +8,37 @@ import org.osgi.framework.BundleContext;
  */
 public class LibertyDevPlugin extends AbstractUIPlugin {
 
-	// The plug-in ID
-	public static final String PLUGIN_ID = "liberty"; //$NON-NLS-1$
+    // The plug-in ID
+    public static final String PLUGIN_ID = "liberty"; //$NON-NLS-1$
 
-	// The shared instance
-	private static LibertyDevPlugin plugin;
-	
-	/**
-	 * The constructor
-	 */
-	public LibertyDevPlugin() {
-	}
+    // The shared instance
+    private static LibertyDevPlugin plugin;
 
-	@Override
-	public void start(BundleContext context) throws Exception {
-		super.start(context);
-		plugin = this;
-	}
+    /**
+     * The constructor
+     */
+    public LibertyDevPlugin() {
+    }
 
-	@Override
-	public void stop(BundleContext context) throws Exception {
-		plugin = null;
-		super.stop(context);
-	}
+    @Override
+    public void start(BundleContext context) throws Exception {
+        super.start(context);
+        plugin = this;
+    }
 
-	/**
-	 * Returns the shared instance
-	 *
-	 * @return the shared instance
-	 */
-	public static LibertyDevPlugin getDefault() {
-		return plugin;
-	}
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        plugin = null;
+        super.stop(context);
+    }
+
+    /**
+     * Returns the shared instance
+     *
+     * @return the shared instance
+     */
+    public static LibertyDevPlugin getDefault() {
+        return plugin;
+    }
 
 }

--- a/liberty/src/liberty/tools/handlers/DevModeMenuHandler.java
+++ b/liberty/src/liberty/tools/handlers/DevModeMenuHandler.java
@@ -7,14 +7,14 @@ import org.eclipse.ui.handlers.HandlerUtil;
 
 public class DevModeMenuHandler extends AbstractHandler {
 
-	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
-		try {
-			HandlerUtil.getActiveWorkbenchWindow(event).getActivePage().showView("liberty.views.liberty.devmode");
-		} catch (Exception e) {
-			throw new ExecutionException("Unable to open the Liberty dashboard view", e);
-		}
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        try {
+            HandlerUtil.getActiveWorkbenchWindow(event).getActivePage().showView("liberty.views.liberty.devmode");
+        } catch (Exception e) {
+            throw new ExecutionException("Unable to open the Liberty dashboard view", e);
+        }
 
-		return null;
-	}
+        return null;
+    }
 }

--- a/liberty/src/liberty/tools/utils/Dialog.java
+++ b/liberty/src/liberty/tools/utils/Dialog.java
@@ -15,49 +15,49 @@ import liberty.tools.LibertyDevPlugin;
 
 public class Dialog {
 
-	static String dTitle = "Liberty Development Mode";
+    static String dTitle = "Liberty Development Mode";
 
-	/**
-	 * Displays an error message dialog with details.
-	 * 
-	 * @param message   The message to display.
-	 * @param throwable The Throwable object to display in the details section.
-	 */
-	public static void displayErrorMessageWithDetails(String message, Throwable throwable) {
+    /**
+     * Displays an error message dialog with details.
+     * 
+     * @param message   The message to display.
+     * @param throwable The Throwable object to display in the details section.
+     */
+    public static void displayErrorMessageWithDetails(String message, Throwable throwable) {
 
-		List<Status> stackTraceStatusList = new ArrayList<>();
-		for (StackTraceElement stackEntry : throwable.getStackTrace()) {
-			Status stackTraceStatus = new Status(IStatus.ERROR, LibertyDevPlugin.PLUGIN_ID, stackEntry.toString());
-			stackTraceStatusList.add(stackTraceStatus);
-		}
+        List<Status> stackTraceStatusList = new ArrayList<>();
+        for (StackTraceElement stackEntry : throwable.getStackTrace()) {
+            Status stackTraceStatus = new Status(IStatus.ERROR, LibertyDevPlugin.PLUGIN_ID, stackEntry.toString());
+            stackTraceStatusList.add(stackTraceStatus);
+        }
 
-		MultiStatus status = new MultiStatus(LibertyDevPlugin.PLUGIN_ID, IStatus.ERROR,
-				stackTraceStatusList.toArray(new Status[] {}), throwable.getMessage(), throwable);
-		Shell shell = Display.getCurrent().getActiveShell();
-		ErrorDialog.openError(shell, dTitle, message, status);
-	}
+        MultiStatus status = new MultiStatus(LibertyDevPlugin.PLUGIN_ID, IStatus.ERROR,
+                stackTraceStatusList.toArray(new Status[] {}), throwable.getMessage(), throwable);
+        Shell shell = Display.getCurrent().getActiveShell();
+        ErrorDialog.openError(shell, dTitle, message, status);
+    }
 
-	/**
-	 * Displays an Error message dialog.
-	 * 
-	 * @param message The message to display.
-	 */
-	public static void displayErrorMessage(String message) {
-		Shell shell = Display.getCurrent().getActiveShell();
-		MessageDialog dialog = new MessageDialog(shell, dTitle, null, message, MessageDialog.ERROR,
-				new String[] { "OK" }, 0);
-		dialog.open();
-	}
+    /**
+     * Displays an Error message dialog.
+     * 
+     * @param message The message to display.
+     */
+    public static void displayErrorMessage(String message) {
+        Shell shell = Display.getCurrent().getActiveShell();
+        MessageDialog dialog = new MessageDialog(shell, dTitle, null, message, MessageDialog.ERROR,
+                new String[] { "OK" }, 0);
+        dialog.open();
+    }
 
-	/**
-	 * Displays a Warning message dialog.
-	 * 
-	 * @param message The message to display.
-	 */
-	public static void displayWarningMessage(String message) {
-		Shell shell = Display.getCurrent().getActiveShell();
-		MessageDialog dialog = new MessageDialog(shell, dTitle, null, message, MessageDialog.WARNING,
-				new String[] { "OK" }, 0);
-		dialog.open();
-	}
+    /**
+     * Displays a Warning message dialog.
+     * 
+     * @param message The message to display.
+     */
+    public static void displayWarningMessage(String message) {
+        Shell shell = Display.getCurrent().getActiveShell();
+        MessageDialog dialog = new MessageDialog(shell, dTitle, null, message, MessageDialog.WARNING,
+                new String[] { "OK" }, 0);
+        dialog.open();
+    }
 }

--- a/liberty/src/liberty/tools/utils/Project.java
+++ b/liberty/src/liberty/tools/utils/Project.java
@@ -8,9 +8,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jem.util.emf.workbench.ProjectUtilities;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -20,130 +18,154 @@ import org.eclipse.ui.PlatformUI;
 
 public class Project {
 
-	/**
-	 * Retrieves the project currently selected.
-	 * 
-	 * @return The project currently selected or null if one was not found.
-	 */
-	public static IProject getSelected() {
-		IProject project = null;
-		IWorkbenchWindow w = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		ISelectionService selectionService = w.getSelectionService();
-		ISelection selection = selectionService.getSelection();
+    /**
+     * Retrieves the project currently selected.
+     * 
+     * @return The project currently selected or null if one was not found.
+     */
+    public static IProject getSelected() {
+        IProject project = null;
+        IWorkbenchWindow w = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        ISelectionService selectionService = w.getSelectionService();
+        ISelection selection = selectionService.getSelection();
 
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection structuredSelection = (IStructuredSelection) selection;
-			Object firstElement = structuredSelection.getFirstElement();
-			project = ProjectUtilities.getProject(firstElement);
-			if (project == null && (firstElement instanceof String)) {
-				project = getByName((String) firstElement);
-			}
-			if (project == null && (firstElement instanceof IProject)) {
-				project = ((IProject) firstElement);
-			}
-			if (firstElement instanceof IResource) {
-				project = ((IResource) firstElement).getProject();
-			}
-		}
+        if (selection instanceof IStructuredSelection) {
+            IStructuredSelection structuredSelection = (IStructuredSelection) selection;
+            Object firstElement = structuredSelection.getFirstElement();
+            project = ProjectUtilities.getProject(firstElement);
+            if (project == null && (firstElement instanceof String)) {
+                project = getByName((String) firstElement);
+            }
+            if (project == null && (firstElement instanceof IProject)) {
+                project = ((IProject) firstElement);
+            }
+            if (firstElement instanceof IResource) {
+                project = ((IResource) firstElement).getProject();
+            }
+        }
 
-		return project;
-	}
-	
-	/**
-	 * Gets all open Java projects currently in the workspace.
-	 * 
-	 * @return All open Java projects currently in the workspace.
-	 */
-	public static List<String> getWokspaceJavaProjects() {
-		List<String> jProjects = new ArrayList<String>();
+        return project;
+    }
 
-		IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
-		IProject[] projects = workspaceRoot.getProjects();
-		try {
-			for (int i = 0; i < projects.length; i++) {
-				IProject project = projects[i];
+    /**
+     * Gets all open projects currently in the workspace.
+     * 
+     * @return All open projects currently in the workspace.
+     */
+    public static List<String> getOpenWokspaceProjects() {
+        List<String> jProjects = new ArrayList<String>();
 
-				if (project.isOpen() && project.hasNature(JavaCore.NATURE_ID)) {
-					jProjects.add(project.getName());
-				}
-			}
-		} catch (CoreException ce) {
-			System.out.println("Unable to retrive a list of open projects. Error: " + ce.getMessage());
-		}
+        IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+        IProject[] projects = workspaceRoot.getProjects();
+        for (int i = 0; i < projects.length; i++) {
+            IProject project = projects[i];
 
-		return jProjects;
-	}
-	
-	/**
-	 * Retrieves the IProject object associated with the input name.
-	 * 
-	 * @param name The name of the project.
-	 * 
-	 * @return The IProject object associated with the input name.
-	 */
-	public static IProject getByName(String name) {
+            if (project.isOpen()) {
+                jProjects.add(project.getName());
+            }
+        }
 
-		try {
-			IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+        return jProjects;
+    }
 
-			IProject[] projects = workspaceRoot.getProjects();
-			for (int i = 0; i < projects.length; i++) {
-				IProject project = projects[i];
-				if (project.isOpen() && (project.getName().equals(name))) {
-					return project;
-				}
-			}
-		} catch (Exception ce) {
+    /**
+     * Retrieves the IProject object associated with the input name.
+     * 
+     * @param name The name of the project.
+     * 
+     * @return The IProject object associated with the input name.
+     */
+    public static IProject getByName(String name) {
 
-		}
-		return null;
-	}
-	
-	/**
-	 * Retrieves the absolute path of the currently selected project.
-	 *
-	 * @param selectedProject The project object
-	 * 
-	 * @return The absolute path of the currently selected project or null if the
-	 *         path could not be obtained.
-	 */
-	public static String getPath(IProject project) {
-		if (project != null) {
-			IPath path = project.getLocation();
-			if (path != null) {
-				return path.toPortableString();
-			}
-		}
+        try {
+            IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
 
-		return null;
-	}
-	
-	public static boolean isMaven(IProject project) {
-		// TODO: Handle cases where pom.xml is not in the root dir.
-		IFile file = project.getFile("pom.xml");
-		return file.exists();
-	}
-	
-	public static boolean isGradle(IProject project) {
-		// TODO: Handle cases where build.gradle is not in the root dir.
-		IFile file = project.getFile("build.gradle");
-		return file.exists();
-	}
+            IProject[] projects = workspaceRoot.getProjects();
+            for (int i = 0; i < projects.length; i++) {
+                IProject project = projects[i];
+                if (project.isOpen() && (project.getName().equals(name))) {
+                    return project;
+                }
+            }
+        } catch (Exception ce) {
 
-	
-	public static boolean isMavenBuildFileValid(IProject project) {
-		IFile file = project.getFile("pom.xml");
-		
-		// TODO: Implement. Check for Liberty Maven plugin and other needed definitions. Need some parsing tool.
-		
-		return true;
-	}
-	
-	public static boolean isGradleBuildFileValid(IProject project) {
-		IFile file = project.getFile("build.gradle");
-		
-		// TODO: Implement.  Check for Liberty Gradle plugin and other needed definitions. Need some xml parsing tool.
-		
-		return true;
-	}
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the absolute path of the currently selected project.
+     *
+     * @param selectedProject The project object
+     * 
+     * @return The absolute path of the currently selected project or null if the path could not be obtained.
+     */
+    public static String getPath(IProject project) {
+        if (project != null) {
+            IPath path = project.getLocation();
+            if (path != null) {
+                return path.toPortableString();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns true if the input project is a Maven project. False otherwise.
+     * 
+     * @param project The project to check.
+     * 
+     * @return True if the input project is a Maven project. False, otherwise.
+     */
+    public static boolean isMaven(IProject project) {
+        // TODO: Handle cases where pom.xml is not in the root dir.
+        IFile file = project.getFile("pom.xml");
+        return file.exists();
+    }
+
+    /**
+     * Returns true if the input project is a Gradle project. False, otherwise.
+     * 
+     * @param project The project to check.
+     * 
+     * @return True if the input project is a Gradle project. False otherwise.
+     */
+    public static boolean isGradle(IProject project) {
+        // TODO: Handle cases where build.gradle is not in the root dir.
+        IFile file = project.getFile("build.gradle");
+        return file.exists();
+    }
+
+    /**
+     * Returns true if the Maven project's pom.xml file is configured to use Liberty development mode. False, otherwise.
+     * 
+     * @param project The Maven project.
+     * 
+     * @return True if the Maven project's pom.xml file is configured to use Liberty development mode. False, otherwise.
+     */
+    public static boolean isMavenBuildFileValid(IProject project) {
+        IFile file = project.getFile("pom.xml");
+
+        // TODO: Implement. Check for Liberty Maven plugin and other needed definitions.
+        // Need some parsing tool.
+
+        return true;
+    }
+
+    /**
+     * Returns true if the Gradle project's build file is configured to use Liberty development mode. False, otherwise.
+     * 
+     * @param project The Gradle project.
+     * 
+     * @return True if the Gradle project's build file is configured to use Liberty development mode. False, otherwise.
+     */
+    public static boolean isGradleBuildFileValid(IProject project) {
+        IFile file = project.getFile("build.gradle");
+
+        // TODO: Implement. Check for Liberty Gradle plugin and other needed
+        // definitions. Need some xml parsing tool.
+
+        return true;
+    }
 }


### PR DESCRIPTION
This PR:
- Fixes devMode operations menu appearing when right clicking on empty window. Now, the menu only appears when a project is selected.
- Fixes right click menu actions to reflect what can and cannot be down with gradle and mave projects when it comes to test results.
- Adds base code to find maven/gradle/java installations. Not yet fully usable. To see terminal action. Installation paths for Maven and Gradle must be set manually. See TODOs.
- Adds code to be able to displaying HTML test results on an internal browser by default. If the eclipse installation does not provide an internal browser, then an external browser is used. This is not fully complete as it needs to handle custom report paths for Gradle. See TODO.